### PR TITLE
fix(#75): slide export

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.1.0",
     "eslint": "^8.46.0",
+    "playwright-chromium": "^1.36.2",
     "prettier": "^3.0.0",
     "sinon": "^15.2.0",
     "ts-node-dev": "^2.0.0",

--- a/src/solutions/step-02-setting-up-host/.eslintrc.json
+++ b/src/solutions/step-02-setting-up-host/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "rules": {
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",

--- a/src/solutions/step-03-bidirectional/nextApp/.eslintrc.json
+++ b/src/solutions/step-03-bidirectional/nextApp/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "rules": {
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",

--- a/src/solutions/step-04-shared-dependencies/nextApp/.eslintrc.json
+++ b/src/solutions/step-04-shared-dependencies/nextApp/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "rules": {
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",

--- a/src/step-02-setting-up-host/nextApp/.eslintrc.json
+++ b/src/step-02-setting-up-host/nextApp/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "rules": {
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",

--- a/src/step-03-bidirectional/nextApp/.eslintrc.json
+++ b/src/step-03-bidirectional/nextApp/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "rules": {
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",

--- a/src/step-04-shared-dependencies/nextApp/.eslintrc.json
+++ b/src/step-04-shared-dependencies/nextApp/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "rules": {
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6211,6 +6211,18 @@ plantuml-encoder@^1.4.0:
   resolved "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.4.0.tgz"
   integrity sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g==
 
+playwright-chromium@^1.36.2:
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/playwright-chromium/-/playwright-chromium-1.36.2.tgz#c11bd46895eba0a96648056095e9d06dbe51f822"
+  integrity sha512-ONY6+ON1A+qYUBiymWn3MHnBjdPO6lYIi2SiQbUo1OA0cSZaxx9vM2mRYY3p7JLC6AhAbPEimZdXetQx48AHkA==
+  dependencies:
+    playwright-core "1.36.2"
+
+playwright-core@1.36.2:
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.36.2.tgz#32382f2d96764c24c65a86ea336cf79721c2e50e"
+  integrity sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==
+
 popmotion@^11.0.5:
   version "11.0.5"
   resolved "https://registry.npmjs.org/popmotion/-/popmotion-11.0.5.tgz"


### PR DESCRIPTION
Resolves https://github.com/nearform/the-micro-frontends-workshop/issues/75.
1. Fixes the root `yarn export` script by adding the missing dev dependency
2. Fixes `lint` script errors caused by conflicting eslintrc configurations