### PR TITLE
chore(deps): group minor + patch dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,26 @@
+---
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    ignore:
-        # Pending complete resolution of https://github.com/module-federation/universe/issues/1102
-        # This exception should be removed as part of https://github.com/nearform/the-micro-frontends-workshop/issues/32
-      - dependency-name: "@module-federation/nextjs-mf"
-        versions: ["6.x", "7.x"]
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  ignore:
+  - dependency-name: "@module-federation/nextjs-mf"
+    versions:
+    - 6.x
+    - 7.x
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    minor-and-patch:
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
Adds a `groups` block to `.github/dependabot.yml` bundling **minor + patch** updates into one PR per ecosystem; **majors stay as separate PRs**. Stops the individual-PR flood from rebuilding. Config-only. For human review + merge.